### PR TITLE
Add size function to Builder

### DIFF
--- a/library/VectorBuilder/Builder.hs
+++ b/library/VectorBuilder/Builder.hs
@@ -3,6 +3,7 @@ module VectorBuilder.Builder
   Builder,
   empty,
   singleton,
+  size,
   vector,
   foldable,
 )

--- a/library/VectorBuilder/Core/Builder.hs
+++ b/library/VectorBuilder/Core/Builder.hs
@@ -15,6 +15,13 @@ data Builder element =
   Builder !Int !(A.Update element)
 
 
+-- |
+-- Gets the size of a Builder.
+{-# INLINE size #-}
+size :: Builder element -> Int
+size (Builder s _) = s
+
+
 -- * Initialisation
 
 -- |


### PR DESCRIPTION
This adds a function which gives the size of a Builder. This is sometimes useful when recursively adding elements to a Builder in which we wish to use the current length e.g. to create a unique identifier.