### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/vector-builder.cabal
+++ b/vector-builder.cabal
@@ -77,9 +77,11 @@ library
     VectorBuilder.Core.Builder
   build-depends:
     vector >=0.11 && <0.13,
-    semigroups >=0.16 && <0.20,
     base-prelude <2,
     base >=4.8 && <5
+  if impl(ghc < 8.0)
+    build-depends:
+      semigroups >=0.16 && <0.20
 
 test-suite tests
   type:


### PR DESCRIPTION
They are not needed on newer GHC.